### PR TITLE
Fix comments messing up line extensions in directives

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Download package
       id: download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2024-10-18
+
+### Fixed
+
+- Fixed in-directive comments messing up line extensions.
+
 ## [1.0.0] - 2024-10-17
 
 ### Added

--- a/SLCommandScript.Core.UnitTests/ScriptUtilsTests.cs
+++ b/SLCommandScript.Core.UnitTests/ScriptUtilsTests.cs
@@ -9,7 +9,8 @@ public class ScriptUtilsTests
     private static readonly string[][] _errorPaths = [
         ["xd", "Command 'xd' was not found"],
         ["[ bc if bc", "Missing closing square bracket for directive"],
-        ["[", "Directive structure is invalid"]
+        ["[", "Directive structure is invalid"],
+        ["[help #comment \n ]", "Directive structure is invalid"]
     ];
 
     private static readonly string[] _goldPaths = [

--- a/SLCommandScript.Core/Constants.cs
+++ b/SLCommandScript.Core/Constants.cs
@@ -13,7 +13,7 @@ public static class Constants
     /// <summary>
     /// Contains current project version.
     /// </summary>
-    public const string ProjectVersion = "1.0.0";
+    public const string ProjectVersion = "1.0.1";
 
     /// <summary>
     /// Contains project author.

--- a/SLCommandScript.Core/Language/Lexer.cs
+++ b/SLCommandScript.Core/Language/Lexer.cs
@@ -608,6 +608,7 @@ public class Lexer
             return;
         }
 
+        _depth = 0;
         var action = Skip;
 
         if (Match('!'))

--- a/SLCommandScript.Core/SLCommandScript.Core.csproj
+++ b/SLCommandScript.Core/SLCommandScript.Core.csproj
@@ -30,7 +30,7 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<Title>SLCommandScript.Core</Title>
 		<Copyright>Copyright © 2023-present Adam Szerszenowicz</Copyright>
-		<PackageVersion>1.0.0</PackageVersion>
+		<PackageVersion>1.0.1</PackageVersion>
 		<PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/SLCommandScript/Plugin.cs
+++ b/SLCommandScript/Plugin.cs
@@ -21,7 +21,7 @@ public class Plugin
     /// <summary>
     /// Contains current plugin version.
     /// </summary>
-    public const string PluginVersion = "1.0.0";
+    public const string PluginVersion = "1.0.1";
 
     /// <summary>
     /// Contains plugin description.


### PR DESCRIPTION
## Description
The goal is to fix invalid line extensions behavior when comment is placed inside a directive.

## Resolution
Quards now reset lexer scope depth.

## Testing Evidence
Added new test for covering this case. All tests are passing.

## Related PRs/Dependencies
N/A

## Before merging
- [x] If non-cosmetic changes were introduced -> Update project version and changelog.
- [x] If changes were made in Core project -> Update NuGet package version.
- [x] Make sure documentation regarding added/changed elements is up to date.