### PR TITLE
Fixed publish fail when nuget package is missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,3 @@ jobs:
         plugin-name: SLCommandScript
         refs-variable: SL_REFERENCES
         dependencies: SLCommandScript.Core,SLCommandScript.FileScriptsLoader
-        depot-downloader-version: 2.7.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,4 @@ jobs:
         plugin-name: SLCommandScript
         refs-variable: SL_REFERENCES
         dependencies: SLCommandScript.Core,SLCommandScript.FileScriptsLoader
+        depot-downloader-version: 2.7.4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,17 +10,20 @@ jobs:
     steps:
     - name: Download package
       id: download
+      continue-on-error: true
       uses: robinraju/release-downloader@v1
       with:
         fileName: '*.nupkg'
         tag: ${{ github.event.release.tag_name }}
 
     - name: Setup .NET
+      if: steps.download.outcome == 'success'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
     - name: Publish package
+      if: steps.download.outcome == 'success'
       run: |
         dotnet nuget push ${{ fromJson(steps.download.outputs.downloaded_files)[0] }} --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/Pogromca-SCP/index.json --skip-duplicate
         dotnet nuget push ${{ fromJson(steps.download.outputs.downloaded_files)[0] }} --api-key ${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Description
This PR fixes publish workflow failures when nuget package is missing.

## Resolution
Nuget package download failures are ignored.

## Testing Evidence
Run locally.

## Before merging
- [ ] If non-cosmetic changes were introduced -> Update project version and changelog.
- [ ] If changes were made in Core project -> Update NuGet package version.
- [ ] Make sure documentation regarding added/changed elements is up to date.