### PR TITLE
Improved dispose methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- File scripts loader components now utilize dispose pattern properly.
 - File scripts loader was updated to no longer rely on static properties and files/directories location tracking.
 - Project now uses NwPluginAPI assembly directly from game files to use more up to date API.
 

--- a/SLCommandScript.FileScriptsLoader.UnitTests/Loader/EventsDirectoryTests.cs
+++ b/SLCommandScript.FileScriptsLoader.UnitTests/Loader/EventsDirectoryTests.cs
@@ -184,7 +184,7 @@ public class EventsDirectoryTests : TestWithConfigBase
     }
 
     [Test]
-    public void Dispose_ShouldUnregisterEvents_WhenWatcherIsNull()
+    public void Dispose_ShouldDoNothing_WhenWatcherIsNull()
     {
         // Arrange
         var dir = MakeSupressed(_plugin, null, RuntimeConfig);

--- a/SLCommandScript.FileScriptsLoader/FileScriptsLoader.cs
+++ b/SLCommandScript.FileScriptsLoader/FileScriptsLoader.cs
@@ -91,23 +91,24 @@ public class FileScriptsLoader : IScriptsLoader
         PrintLog("Scripts loader is initialized.");
     }
 
-    /// <summary>
-    /// Releases resources.
-    /// </summary>
-    ~FileScriptsLoader() => PerformCleanup();
-
     /// <inheritdoc />
     public void Dispose()
     {
-        PerformCleanup();
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
     /// <summary>
     /// Unloads scripts and helpers.
     /// </summary>
-    protected void PerformCleanup()
+    /// <param name="disposing">Whether or not this method is invoked from <see cref="Dispose()" />.</param>
+    protected virtual void Dispose(bool disposing)
     {
+        if (!disposing)
+        {
+            return;
+        }
+
         PrintLog("Disabling scripts loader...");
 
         foreach (var dir in _registeredDirectories)

--- a/SLCommandScript.FileScriptsLoader/Helpers/FileSystemWatcherHelper.cs
+++ b/SLCommandScript.FileScriptsLoader/Helpers/FileSystemWatcherHelper.cs
@@ -99,15 +99,10 @@ public class FileSystemWatcherHelper : IFileSystemWatcherHelper
         };
     }
 
-    /// <summary>
-    /// Releases resources.
-    /// </summary>
-    ~FileSystemWatcherHelper() => DisposeWatcher();
-
     /// <inheritdoc />
     public void Dispose()
     {
-        DisposeWatcher();
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
@@ -120,9 +115,12 @@ public class FileSystemWatcherHelper : IFileSystemWatcherHelper
     /// <summary>
     /// Disposes wrapped watcher.
     /// </summary>
-    protected void DisposeWatcher()
+    /// <param name="disposing">Whether or not this method is invoked from <see cref="Dispose()" />.</param>
+    protected virtual void Dispose(bool disposing)
     {
-        _watcher.EnableRaisingEvents = false;
-        _watcher.Dispose();
+        if (disposing)
+        {
+            _watcher.Dispose();
+        }
     }
 }

--- a/SLCommandScript.FileScriptsLoader/Loader/CommandsDirectory.cs
+++ b/SLCommandScript.FileScriptsLoader/Loader/CommandsDirectory.cs
@@ -88,15 +88,10 @@ public class CommandsDirectory : IDisposable, IFileScriptCommandParent
         Watcher.Error += (obj, args) => FileScriptsLoader.PrintError($"A {HandlerType} commands watcher error has occured: {args.GetException().Message}");
     }
 
-    /// <summary>
-    /// Releases resources.
-    /// </summary>
-    ~CommandsDirectory() => DisposeAndUnregisterCommands();
-
     /// <inheritdoc />
     public void Dispose()
     {
-        DisposeAndUnregisterCommands();
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
@@ -106,8 +101,14 @@ public class CommandsDirectory : IDisposable, IFileScriptCommandParent
     /// <summary>
     /// Disposes the watcher and performs command cleanup.
     /// </summary>
-    protected void DisposeAndUnregisterCommands()
+    /// <param name="disposing">Whether or not this method is invoked from <see cref="Dispose()" />.</param>
+    protected virtual void Dispose(bool disposing)
     {
+        if (!disposing)
+        {
+            return;
+        }
+
         Watcher?.Dispose();
 
         foreach (var command in Commands.Values)

--- a/SLCommandScript.FileScriptsLoader/Loader/EventsDirectory.cs
+++ b/SLCommandScript.FileScriptsLoader/Loader/EventsDirectory.cs
@@ -78,15 +78,10 @@ public class EventsDirectory : IDisposable, IFileScriptCommandParent
         Watcher.RegisterEvents(PluginObject, Handler);
     }
 
-    /// <summary>
-    /// Releases resources.
-    /// </summary>
-    ~EventsDirectory() => DisposeAndUnregisterEvents();
-
     /// <inheritdoc />
     public void Dispose()
     {
-        DisposeAndUnregisterEvents();
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
@@ -96,16 +91,20 @@ public class EventsDirectory : IDisposable, IFileScriptCommandParent
     /// <summary>
     /// Disposes the watcher and unregisters events.
     /// </summary>
-    protected void DisposeAndUnregisterEvents()
+    /// <param name="disposing">Whether or not this method is invoked from <see cref="Dispose()" />.</param>
+    protected virtual void Dispose(bool disposing)
     {
-        Watcher?.Dispose();
-
-        if (PluginObject is null || Watcher is null)
+        if (!disposing)
         {
             return;
         }
 
-        Watcher.UnregisterEvents(PluginObject, Handler);
+        if (PluginObject is not null)
+        {
+            Watcher?.UnregisterEvents(PluginObject, Handler);
+        }
+
+        Watcher?.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
Current implementation of `Dispose` methods aren't compatible with standard pattern and can potentially cause issues due to inappropriate usage of finalizers.

## Resolution
`Dispose` methods were adjusted to match the `Basic Dispose Pattern`.

## Testing Evidence
Tested on local server instance.

## Related PRs/Dependencies
N/A

## Before merging
- [x] If non-cosmetic changes were introduced -> Update project version and changelog.
- [x] If changes were made in Core project -> Update NuGet package version.
- [x] Make sure documentation regarding added/changed elements is up to date.
